### PR TITLE
wyl: 修复交易详情页面的去向内容点击没跳转路由问题

### DIFF
--- a/src/views/TransactionDetails/index.vue
+++ b/src/views/TransactionDetails/index.vue
@@ -46,7 +46,7 @@
                 <ul class="TxMessage_show">
                   <li class="TxMessage_label">去向</li>
                   <li class="TxMessage_value">
-                    <el-link type="primary" :underline="false">{{Msgs.to}}</el-link>
+                    <el-link type="primary" :underline="false" @click="() => this.$router.push({ path: `/account/${Msgs.to}` })">{{Msgs.to}}</el-link>
                   </li>
                 </ul>
                 <ul class="TxMessage_show">


### PR DESCRIPTION
wyl: 修复交易详情页面的去向内容点击没跳转路由问题